### PR TITLE
PES-5714: replace deprecated UIGraphicsBeginImageContextWithOptions

### DIFF
--- a/components/TextFields/src/MDCTextInputControllerLegacyDefault.m
+++ b/components/TextFields/src/MDCTextInputControllerLegacyDefault.m
@@ -76,12 +76,14 @@ static CGFloat _underlineHeightNormalLegacyDefault =
 
   CGFloat scale = [UIScreen mainScreen].scale;
   CGRect bounds = CGRectMake(0, 0, clearButtonSize.width * scale, clearButtonSize.height * scale);
-  UIGraphicsBeginImageContextWithOptions(bounds.size, false, scale);
-  [color setFill];
+  UIGraphicsImageRendererFormat *format = [[UIGraphicsImageRendererFormat alloc] init];
+  format.scale = scale;
+  UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:bounds.size format:format];
+  UIImage *image = [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull rendererContext) {
+    [color setFill];
 
-  [MDCPathForClearButtonLegacyImageFrame(bounds) fill];
-  UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
-  UIGraphicsEndImageContext();
+    [MDCPathForClearButtonLegacyImageFrame(bounds) fill];
+  }];
 
   image = [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
   return image;

--- a/components/TextFields/src/MDCTextInputControllerLegacyFullWidth.m
+++ b/components/TextFields/src/MDCTextInputControllerLegacyFullWidth.m
@@ -49,12 +49,14 @@ static const CGFloat kButtonFontOpacity = 0.54f;
 
   CGFloat scale = [UIScreen mainScreen].scale;
   CGRect bounds = CGRectMake(0, 0, clearButtonSize.width * scale, clearButtonSize.height * scale);
-  UIGraphicsBeginImageContextWithOptions(bounds.size, false, scale);
-  [color setFill];
+  UIGraphicsImageRendererFormat *format = [[UIGraphicsImageRendererFormat alloc] init];
+  format.scale = scale;
+  UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:bounds.size format:format];
+  UIImage *image = [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull rendererContext) {
+    [color setFill];
 
-  [MDCPathForClearButtonLegacyImageFrame(bounds) fill];
-  UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
-  UIGraphicsEndImageContext();
+    [MDCPathForClearButtonLegacyImageFrame(bounds) fill];
+  }];
 
   image = [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
   return image;

--- a/components/TextFields/src/private/MDCTextInputCommonFundament.m
+++ b/components/TextFields/src/private/MDCTextInputCommonFundament.m
@@ -624,12 +624,12 @@ static inline UIColor *MDCTextInputUnderlineColor(void) { return [UIColor lightG
                                       MDCTextInputClearButtonImageSquareWidthHeight);
 
   CGRect bounds = CGRectMake(0, 0, clearButtonSize.width, clearButtonSize.height);
-  UIGraphicsBeginImageContextWithOptions(bounds.size, false, 0);
-  [UIColor.grayColor setFill];
-
-  [MDCPathForClearButtonImageFrame(bounds) fill];
-  UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
-  UIGraphicsEndImageContext();
+  UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:bounds.size];
+  UIImage *image = [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull rendererContext) {
+      [UIColor.grayColor setFill];
+      
+      [MDCPathForClearButtonImageFrame(bounds) fill];
+  }];
 
   image = [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
   return image;


### PR DESCRIPTION
<img width="543" alt="image" src="https://github.com/myxplor/material-components-ios/assets/112909847/29fdd159-ed39-49de-a917-d90a113ce6c0">

[PES-5714](https://myxplorinfo.atlassian.net/browse/PES-5714)



[PES-5714]: https://myxplorinfo.atlassian.net/browse/PES-5714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ